### PR TITLE
build: bump dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["BatchMixpanelSwiftDispatcher"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mixpanel/mixpanel-swift", from: "2.8.0"),
-        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK", from: "1.17.0"),
+        .package(url: "https://github.com/mixpanel/mixpanel-swift", from: "4.1.0"),
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK", from: "1.20.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
No changes seem to be required, I can't run the tests as they are not usable from SPM.
Would you like me to check if I can add the tests to SPM ? This would require adding a dependency to the mock lib used.